### PR TITLE
Fix generator picker not focused

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,6 +1,6 @@
 'use strict';
 
-import {window, workspace, commands, ExtensionContext, Uri} from 'vscode';
+import {window, workspace, commands, ExtensionContext, Uri, OutputChannel} from 'vscode';
 import EscapeException from './utils/EscapeException';
 import Yeoman from './yo/yo';
 import listGenerators from './utils/list-generators';
@@ -11,6 +11,7 @@ export function activate(context: ExtensionContext) {
 
 	const yeomanCommand = 'yeoman.yeoman';
 	const yoCommand = 'yeoman.yo';
+	const outChannel = window.createOutputChannel('Yeoman');
 
 	const commandHandler = (currentFolderUri?: Uri) => {
 		let cwd = currentFolderUri ? currentFolderUri.fsPath : workspace.rootPath;
@@ -19,7 +20,7 @@ export function activate(context: ExtensionContext) {
 			return;
 		}
 
-		const yo = new Yeoman({cwd});
+		const yo = new Yeoman({cwd, outChannel});
 		let main;
 		let sub;
 
@@ -27,6 +28,7 @@ export function activate(context: ExtensionContext) {
 			placeHolder: 'Select one of the available Yeoman generators below.', 
 			ignoreFocusOut: true
 		})).then((generator: any) => {
+				outChannel.show(true);
 				if (generator === undefined) {
 					throw new EscapeException();
 				}

--- a/src/test/list-generators.test.ts
+++ b/src/test/list-generators.test.ts
@@ -1,10 +1,12 @@
 import Yeoman from "../yo/yo";
 import { expect } from "chai";
 import listGenerators from "../utils/list-generators";
+import { window } from "vscode";
 
 describe("List generators", () => {
 	it("locally installed generators are available", async () => {
-		let quickPicks = await listGenerators(new Yeoman({cwd: __dirname}));
+		const outChannel = window.createOutputChannel('Yeoman');
+		const quickPicks = await listGenerators(new Yeoman({cwd: __dirname, outChannel}));
 		// generator-generator should be visible as it is a dev dependency of this project
 		expect(quickPicks.map(_ => _.label)).to.contain("generator");
 	});

--- a/src/yo/adapter.ts
+++ b/src/yo/adapter.ts
@@ -16,8 +16,6 @@ export default class CodeAdapter {
 		let self = this;
 
 		this.outChannel = outChannel;
-		this.outChannel.clear();
-		this.outChannel.show();
 
 		this.log.write = function() {
 			const line = util.format.apply(util, arguments);

--- a/src/yo/yo.ts
+++ b/src/yo/yo.ts
@@ -10,6 +10,11 @@ const figures = require('figures');
 
 const frame = elegantSpinner();
 
+interface Options {
+	cwd: string;
+	outChannel: OutputChannel;
+}
+
 export default class Yeoman {
 
 	private _env: any;
@@ -17,9 +22,9 @@ export default class Yeoman {
 	private _interval: any;
 	private outChannel: OutputChannel;
 
-	public constructor(options?: any) {
-		this.outChannel = window.createOutputChannel('Yeoman');
-		this._env = createEnvironment(this.outChannel, undefined, options);
+	public constructor(options: Options) {
+		this.outChannel = options.outChannel;
+		this._env = createEnvironment(this.outChannel, undefined, {cwd: options.cwd});
 		this._status = window.createStatusBarItem(StatusBarAlignment.Left);
 		this._interval;
 	}


### PR DESCRIPTION
This PR solves two things.
* When generator list is shown it loses focus forcing user to click it in order to select or search for generators.
  Happens because [showQuickPick()](https://github.com/camel-tooling/vscode-yeoman/blob/0.9.10/src/extension.ts#L26) is displayed before [outChannel.show()](https://github.com/camel-tooling/vscode-yeoman/blob/0.9.10/src/yo/adapter.ts#L20) which takes the focus.
* Invoking a generator creates a new Yeoman output console. Normally these consoles should be [disposed](https://code.visualstudio.com/api/references/vscode-api#OutputChannel) as there is no option for the user to close them.
  This patch brings vscode-yeoman more in line with other extensions that create only one output and reuse it.

